### PR TITLE
Initial Travis setup

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^\.git
 ^inst/cppzmq/\.git
 ^README.rst$
+^\.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,9 @@
-# Sample .travis.yml for R projects.
-#
-# See README.md for instructions, or for more configuration options,
-# see the wiki:
-#   https://github.com/craigcitro/r-travis/wiki
+language: r
+sudo: required
 
-language: c
+# Be strict when checking the package
+warnings_are_errors: true
 
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-  - apt-get install libzmq3-dev
-install:
-  - ./travis-tool.sh 
-  - ./travis-tool.sh install_deps
-script: ./travis-tool.sh run_tests
-
-after_failure:
-  - ./travis-tool.sh dump_logs
-
-notifications:
-  email:
-    on_success: change
-    on_failure: change
+# System dependencies for HTTP calling
+apt_packages:
+ - libzmq3-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+# Sample .travis.yml for R projects.
+#
+# See README.md for instructions, or for more configuration options,
+# see the wiki:
+#   https://github.com/craigcitro/r-travis/wiki
+
+language: c
+
+before_install:
+  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - chmod 755 ./travis-tool.sh
+  - ./travis-tool.sh bootstrap
+  - apt-get install libzmq3-dev
+install:
+  - ./travis-tool.sh 
+  - ./travis-tool.sh install_deps
+script: ./travis-tool.sh run_tests
+
+after_failure:
+  - ./travis-tool.sh dump_logs
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change


### PR DESCRIPTION
This uses https://github.com/craigcitro/r-travis to setup Travis builds for rzmq. You'll need to add the actual integration with Travis after merge.