### PR TITLE
use platform-specific endian encoding

### DIFF
--- a/R/rzmq.R
+++ b/R/rzmq.R
@@ -47,9 +47,10 @@ disconnect.socket <- function(socket, address) {
     invisible(.Call("disconnectSocket", socket, address, PACKAGE="rzmq"))
 }
 
-send.socket <- function(socket, data, send.more=FALSE, serialize=TRUE) {
+send.socket <- function(socket, data, send.more=FALSE, serialize=TRUE,
+                        xdr=.Platform$endian=="big") {
     if(serialize) {
-        data <- serialize(data,NULL)
+        data <- serialize(data, NULL, xdr=xdr)
     }
 
     invisible(.Call("sendSocket", socket, data, send.more, PACKAGE="rzmq"))


### PR DESCRIPTION
see: https://github.com/armstrtw/rzmq/issues/19

> There is an option in R's serialize() function that determines whether data is serialized in big- or little endian format. Big endian is default, which doesn't make much sense, because most current systems use little endian. This has a performance penalty that could easily be avoided by setting the option xdr=FALSE in rzmq.R#L52 (but could be queried using .Platform$endian or combined to xdr=.Platform$endian=="big").

This is how I'd go about it - don't think anything more complicated than this is necessary (defaults to current platform, can be overwritten by user on call to `send.socket()`).