### PR TITLE
use pkg-config to find libzmq's location

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,5 @@
 ## -*- mode: makefile; -*-
 
 CXX_STD = CXX11
-PKG_CPPFLAGS = -I../inst
-PKG_LIBS = -lzmq
+PKG_CPPFLAGS = -I../inst $(shell pkg-config --cflags libzmq)
+PKG_LIBS = $(shell pkg-config --libs libzmq)

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,13 @@
 ## -*- mode: makefile; -*-
 
 CXX_STD = CXX11
+
+ifeq (,$(shell which pkg-config))
+# if the pkg-config program isn't found
+PKG_CPPFLAGS = -I../inst
+PKG_LIBS = -lzmq
+else
+# if the pkg-config program is found
 PKG_CPPFLAGS = -I../inst $(shell pkg-config --cflags libzmq)
 PKG_LIBS = $(shell pkg-config --libs libzmq)
+endif


### PR DESCRIPTION
This change allows rzmq to correctly find the zeromq library and header files with `pkg-config` if zeromq is installed in standard (e.g. `/usr/lib`, `/usr/local/lib`, `/usr/include`, `/usr/local/include`) or other alternative locations on the file system.
