### PR TITLE
Proper build on all platforms

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,7 @@
 ^\.git
 ^inst/cppzmq/\.git
 ^README.rst$
+^.*\.Rproj$
+^\.Rproj\.user$
+^src/Makevars$
+^.travis.yml$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@
 ^\.Rproj\.user$
 ^src/Makevars$
 ^.travis.yml$
+^windows$

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@
 *.rc
 *.o
 *.so
+*.dll
 .Rproj.user
 src/Makevars
+windows

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.rc
 *.o
 *.so
+.Rproj.user
+src/Makevars

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+language: r
+cache: packages
+
+matrix:
+  include:
+    - os: linux
+      dist: precise
+      sudo: false
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: R_CODECOV=true
+    - os: osx
+      osx_image: xcode8.1
+      brew_packages: zeromq
+      latex: false
+    - os: osx
+      osx_image: xcode8.1
+      disable_homebrew: true
+      latex: false
+    - os: osx
+      osx_image: xcode6.1
+      disable_homebrew: true
+      latex: false
+
+addons:
+  apt:
+    packages:
+      - libzmq3-dev
+
+r_github_packages:
+  - jimhester/covr
+
+warnings_are_errors: true
+#r_check_revdep: true
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+after_success:
+  - if [[ "${R_CODECOV}" ]]; then R -e 'covr::codecov()'; fi
+
+before_install:
+  - (while true; do echo 'Ping? Pong!'; sleep 500; done) &

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,9 @@
 Package: rzmq
 Title: R Bindings for ZeroMQ
 Version: 0.8.0
-Maintainer: Whit Armstrong <armstrong.whit@gmail.com>
-Author: Whit Armstrong <armstrong.whit@gmail.com>
+Authors@R: c(
+    person("Whit", "Armstrong", , "armstrong.whit@gmail.com", role = c("aut", "cre")),
+    person("Jeroen", "Ooms", , "jeroen.ooms@stat.ucla.edu", role = "aut"))
 Description: Interface to the ZeroMQ lightweight messaging kernel (see <http://www.zeromq.org/> for more information).
 License: GPL-3
 Depends: R (>= 3.1.0)

--- a/cleanup
+++ b/cleanup
@@ -1,0 +1,2 @@
+#!/bin/sh
+rm -f src/Makevars

--- a/configure
+++ b/configure
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Anticonf (tm) script by Jeroen Ooms (2017)
+# This script will query 'pkg-config' for the required cflags and ldflags.
+# If pkg-config is unavailable or does not find the library, try setting
+# INCLUDE_DIR and LIB_DIR manually via e.g:
+# R CMD INSTALL --configure-vars='INCLUDE_DIR=/.../include LIB_DIR=/.../lib'
+
+# Library settings
+PKG_CONFIG_NAME="libzmq"
+PKG_DEB_NAME="libzmq3-dev"
+PKG_RPM_NAME="zeromq3-devel"
+PKG_CSW_NAME="libzmq1_dev"
+PKG_BREW_NAME="zeromq"
+PKG_TEST_HEADER="<zmq.h>"
+PKG_LIBS="-lzmq"
+
+# Use pkg-config if available
+if [ $(command -v pkg-config) ]; then
+  PKGCONFIG_CFLAGS=$(pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME})
+  PKGCONFIG_LIBS=$(pkg-config --libs ${PKG_CONFIG_NAME})
+fi
+
+# Check for custom locations
+if [ "$INCLUDE_DIR" ] || [ "$LIB_DIR" ]; then
+  echo "Found INCLUDE_DIR and/or LIB_DIR!"
+  PKG_CFLAGS="-I$INCLUDE_DIR $PKG_CFLAGS"
+  PKG_LIBS="-L$LIB_DIR $PKG_LIBS"
+elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
+  echo "Found pkg-config cflags and libs!"
+  PKG_CFLAGS=${PKGCONFIG_CFLAGS}
+  PKG_LIBS=${PKGCONFIG_LIBS}
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  if [ $(command -v brew) ]; then
+    BREWDIR=$(brew --prefix)
+  else
+    BREWDIR="/tmp/homebrew"
+    rm -Rf $BREWDIR
+    mkdir -p $BREWDIR
+    echo "Auto-brewing $PKG_BREW_NAME in $BREWDIR..."
+    curl -fsSL https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C $BREWDIR
+    $BREWDIR/bin/brew tap homebrew/versions 2>&1 | perl -pe 's/Warning/Note/gi'
+    HOMEBREW_CACHE="/tmp" $BREWDIR/bin/brew install $PKG_BREW_NAME --force-bottle 2>&1 | perl -pe 's/Warning/Note/gi'
+    rm -f $BREWDIR/opt/$PKG_BREW_NAME/lib/*.dylib
+  fi
+  PKG_CFLAGS="-I$BREWDIR/opt/$PKG_BREW_NAME/include"
+  PKG_LIBS="-L$BREWDIR/opt/$PKG_BREW_NAME/lib $PKG_LIBS"
+fi
+
+# For debugging
+echo "Using PKG_CFLAGS=$PKG_CFLAGS"
+echo "Using PKG_LIBS=$PKG_LIBS"
+
+# Find compiler
+CXXCPP=$(${R_HOME}/bin/R CMD config CXXCPP)
+CXXFLAGS=$(${R_HOME}/bin/R CMD config CXXFLAGS)
+CPPFLAGS=$(${R_HOME}/bin/R CMD config CPPFLAGS)
+
+# Test for libv8
+echo "#include $PKG_TEST_HEADER" | ${CXXCPP} ${CPPFLAGS} ${PKG_CFLAGS} ${CXXFLAGS} -xc++ - >/dev/null 2>&1
+
+if [ $? -ne 0 ]; then
+  echo "------------------------- ANTICONF ERROR ---------------------------"
+  echo "Configuration failed because $PKG_CONFIG_NAME was not found. Try installing:"
+  echo " * deb: $PKG_DEB_NAME (Debian, Ubuntu)"
+  echo " * rpm: $PKG_RPM_NAME (Fedora, EPEL)"
+  echo " * brew: $PKG_BREW_NAME (OSX) -- NOT regular v8! Tap from homebrew/versions"
+  echo " * csw: $PKG_CSW_NAME (Solaris)"
+  echo "To use a custom libv8, set INCLUDE_DIR and LIB_DIR manually via:"
+  echo "R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'"
+  echo "--------------------------------------------------------------------"
+  exit 1;
+fi
+
+# Write to Makevars
+sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" src/Makevars.in > src/Makevars
+
+# Success
+exit 0

--- a/rzmq.Rproj
+++ b/rzmq.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,0 @@
-## -*- mode: makefile; -*-
-
-CXX_STD = CXX11
-PKG_CPPFLAGS = -I../inst
-PKG_LIBS = -lzmq

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,0 +1,3 @@
+CXX_STD = CXX11
+PKG_CPPFLAGS = @cflags@ -I../inst
+PKG_LIBS = @libs@

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,20 @@
+CXX_STD = CXX11
+COMPILED_BY ?= gcc-4.6.3
+GCC_VERSION = ${subst gcc,,${COMPILED_BY}}
+ZEROMQ = ../windows/zeromq-4.2.1
+
+PKG_CPPFLAGS = -DZMQ_STATIC \
+	-I${ZEROMQ}/include -I../inst
+	
+PKG_LIBS = \
+	-L${ZEROMQ}/lib${R_ARCH} \
+	-L${ZEROMQ}/lib${GCC_VERSION}${R_ARCH} \
+	-lzmq -lsodium -liphlpapi -lws2_32
+
+all: clean winlibs
+
+clean:
+	rm -f $(OBJECTS) $(SHLIB)
+
+winlibs:
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" --vanilla "../tools/winlibs.R"

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,0 +1,8 @@
+# Build against precompiled zeromq libs.
+if(!file.exists("../windows/zeromq-4.2.1/include/zmq.h")){
+  if(getRversion() < "3.3.0") setInternet2()
+  download.file("https://github.com/rwinlib/zeromq/archive/v4.2.1.zip", "lib.zip", quiet = TRUE)
+  dir.create("../windows", showWarnings = FALSE)
+  unzip("lib.zip", exdir = "../windows")
+  unlink("lib.zip")
+}


### PR DESCRIPTION
This fixes the build for linux, mac and windows. It uses the same system as other R packages that uses external libraries such as [curl](https://github.com/cran/curl), [openssl](https://github.com/cran/openssl), [V8](https://github.com/cran/V8), [sodium](https://github.com/cran/sodium) and many others.